### PR TITLE
Append a new line character

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -9,4 +9,4 @@ var argv = minimist(process.argv.slice(2));
 
 var options = Object.assign({}, { separator: '', adjectives: 2 }, argv);
 
-process.stdout.write(gfynonce(options));
+console.log(gfynonce(options));


### PR DESCRIPTION
Use `console.log` instead of `stdout.write` as it adds a new line character. This 
improves the usage, because otherwise the next command prompt is appended
after the result of gfynonce.